### PR TITLE
Added init trigger if no initComplete option is passed

### DIFF
--- a/src/datatables.net-vue.vue
+++ b/src/datatables.net-vue.vue
@@ -86,6 +86,11 @@ watch(
 onMounted(() => {
 	const inst = getCurrentInstance();
 	let options: any = props.options || {};
+	if(!Object.prototype.hasOwnProperty.call(options,"initComplete")){
+		options.initComplete = ()=>{
+			this.$emit("init");
+		};
+	}	
 
 	if (props.data) {
 		options.data = props.data;


### PR DESCRIPTION
If initComplete option is passed, parent compenent has the power to catch init from the callback so the lack of trigger is solved.