### PR TITLE
Update datatables.net dependency to latest version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "vue-tsc": "^1.0.16"
   },
   "peerDependencies": {
-    "datatables.net": "^1.13.1",
+    "datatables.net": "^2.0.0",
     "jquery": "^3.6.0",
     "vue": "^3.0.5"
   },


### PR DESCRIPTION
datatables.net is now on 2.0.0, however the vue3 component has it locked in as an older ^1 version.