### PR TITLE
Refactor slot rendering to use Fragment

### DIFF
--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -20,7 +20,8 @@ import {
 	watch,
 	onMounted,
 	onBeforeUnmount,
-	getCurrentInstance
+	getCurrentInstance,
+	Fragment
 } from 'vue';
 import type { Api, Config, ConfigColumns } from 'datatables.net';
 import dtEvents from './dtEvents';
@@ -185,7 +186,7 @@ function createRenderer(slot: any) {
 			',' + meta.row + ',' + meta.col;
 
 		if (!elements[key]) {
-			let content = h('div', slot({
+			let content = h(Fragment, slot({
 				cellData: data,
 				colIndex: meta.col,
 				rowData: row,


### PR DESCRIPTION
Slot render creates 2 div to embed actual content node

```html
<td>
  <div>    <!-- elements[key] -->
    <div>   <!-- h('div', ...) -->
       Cell content
    </div>
  </div>
</td> 
```

This PR will remove the inner div created by `"h('div',"`
```html
<td>
  <div>    <!-- elements[key] -->
     Cell content
  </div>
</td> 
```

Note that comparing with pure js implementation, named slot approach will embed context into nested div elements. My ultermate target is to avoid any nested div.