### PR TITLE
Ensure vnode being unmounted in DataTable component

### DIFF
--- a/src/DataTable.vue
+++ b/src/DataTable.vue
@@ -244,6 +244,7 @@ function deleteElements(dt: Api) {
 
 	for (var i = 0; i < keys.length; i++) {
 		if (keys[i].indexOf(id + ',') === 0) {
+			render(null, elements[keys[i]]); // Ensure vnode to be unmounted correctly
 			delete elements[keys[i]];
 		}
 	}


### PR DESCRIPTION
In the current DT Vue impl, dyanmic slot render is able to be mounted to TD elements. But when table data is changed, dynamic slot renders will not trigger `beforeUnmount` and other lifecyle hooks. So it has potential risks that component is not cleaned up correctly. 

```javascript
class MyCellRenderComponent {
  mounted() {
     console.log('Render mounted')
  }
  beforeUnmounted() {
     console.log('Render beforeUnmounted') // <-- not called
  }
  unmounted() {
     console.log('Render unmounted') // <-- not called
  }
}
```

By using this PR, it will be called